### PR TITLE
Suggestions for buttons

### DIFF
--- a/src/framework/button/CallOutButton.jsx
+++ b/src/framework/button/CallOutButton.jsx
@@ -1,25 +1,21 @@
 
 import React from 'react';
+import classNames from 'classnames';
 
 import Button from './Button.jsx';
 
 const CallOutButton = props => {
+  const classes = classNames('button--callOut', props.classes);
+
+  const extendedProps = Object.assign({}, props, {
+    classes: classes,
+  });
+
   return (
-    <Button
-      classes="button--callOut"
-      iconClasses={props.iconClasses}
-      label={props.label}
-      onClick={props.onClick}
-      disabled={props.disabled}
-    />
+    <Button {...extendedProps} />
   );
 };
 
-CallOutButton.propTypes = {
-  label: Button.propTypes.label,
-  iconClasses: Button.propTypes.iconClasses,
-  onClick: Button.propTypes.onClick,
-  disabled: Button.propTypes.disabled,
-};
+CallOutButton.propTypes = Button.propTypes;
 
 export default CallOutButton;

--- a/src/framework/button/HollowButton.jsx
+++ b/src/framework/button/HollowButton.jsx
@@ -1,25 +1,21 @@
 
 import React from 'react';
+import classNames from 'classnames';
 
 import Button from './Button.jsx';
 
 const HollowButton = props => {
+  const classes = classNames('button--hollow', props.classes);
+
+  const extendedProps = Object.assign({}, props, {
+    classes: classes,
+  });
+
   return (
-    <Button
-      classes="button--hollow"
-      iconClasses={props.iconClasses}
-      label={props.label}
-      onClick={props.onClick}
-      disabled={props.disabled}
-    />
+    <Button {...extendedProps} />
   );
 };
 
-HollowButton.propTypes = {
-  label: Button.propTypes.label,
-  iconClasses: Button.propTypes.iconClasses,
-  onClick: Button.propTypes.onClick,
-  disabled: Button.propTypes.disabled,
-};
+HollowButton.propTypes = Button.propTypes;
 
 export default HollowButton;

--- a/src/framework/button/PrimaryButton.jsx
+++ b/src/framework/button/PrimaryButton.jsx
@@ -1,25 +1,21 @@
 
 import React from 'react';
+import classNames from 'classnames';
 
 import Button from './Button.jsx';
 
 const PrimaryButton = props => {
+  const classes = classNames('button--primary', props.classes);
+
+  const extendedProps = Object.assign({}, props, {
+    classes: classes,
+  });
+
   return (
-    <Button
-      classes="button--primary"
-      iconClasses={props.iconClasses}
-      label={props.label}
-      onClick={props.onClick}
-      disabled={props.disabled}
-    />
+    <Button {...extendedProps} />
   );
 };
 
-PrimaryButton.propTypes = {
-  label: Button.propTypes.label,
-  iconClasses: Button.propTypes.iconClasses,
-  onClick: Button.propTypes.onClick,
-  disabled: Button.propTypes.disabled,
-};
+PrimaryButton.propTypes = Button.propTypes;
 
 export default PrimaryButton;


### PR DESCRIPTION
- hollow, primary and callout buttons also support additional classes
- buttons can be maintained easier because changes to button props often not require changes to hollow, primary and callout buttons
