### PR TITLE
Remove className prop from FieldMessage.

### DIFF
--- a/src/framework/fieldMessage/FieldMessage.jsx
+++ b/src/framework/fieldMessage/FieldMessage.jsx
@@ -2,24 +2,16 @@
 import React, {
   PropTypes,
 } from 'react';
-import classNames from 'classnames';
 
 const FieldMessage = props => {
-  const classes = classNames('fieldMessage', props.className);
-
-  const extendedProps = Object.assign({}, props, {
-    className: classes,
-  });
-
   return (
-    <div {...extendedProps}>
+    <div className="fieldMessage">
       {props.message}
     </div>
   );
 };
 
 FieldMessage.propTypes = {
-  className: PropTypes.string,
   message: PropTypes.string.isRequired,
 };
 

--- a/src/framework/fieldMessage/FieldMessage.spec.jsx
+++ b/src/framework/fieldMessage/FieldMessage.spec.jsx
@@ -4,19 +4,6 @@ import FieldMessage from './FieldMessage.jsx';
 
 describe('FieldMessage', () => {
   describe('Props', () => {
-    describe('className', () => {
-      it('is applied to element', () => {
-        const props = {
-          className: 'test',
-        };
-        const testCase = TestCaseFactory.create(
-          FieldMessage,
-          props
-        );
-        expect(testCase.dom.getAttribute('class')).toContain(props.className);
-      });
-    });
-
     describe('message', () => {
       it('is rendered as text', () => {
         const props = {


### PR DESCRIPTION
We don't need this prop right? I didn't catch it the first time around.
