### PR TITLE
Fix bug with being unable to focus a dropdown

### DIFF
--- a/src/framework/baseDropdown/BaseDropdown.jsx
+++ b/src/framework/baseDropdown/BaseDropdown.jsx
@@ -201,7 +201,6 @@ export default class BaseDropdown extends Component {
           onBlur={this.onBlur}
           onFocus={this.onFocus}
           onKeyDown={this.onKeyDown}
-          type="hidden"
         />
         <div
           className={labelClasses}

--- a/src/framework/baseDropdown/BaseDropdownOption.jsx
+++ b/src/framework/baseDropdown/BaseDropdownOption.jsx
@@ -62,6 +62,8 @@ BaseDropdownOption.propTypes = {
 // These defaults exist for testing purposes. They should never be used in
 // production.
 BaseDropdownOption.defaultProps = {
+  onClick: () => undefined,
+  onMouseOver: () => undefined,
   classes: 'option',
   focusClasses: 'is-option-focus',
 };


### PR DESCRIPTION
I accidentally committed `type="hidden"` for the input when I was testing it out! D'oh.
