### PR TITLE
[BT-438]: Add support for SubLabel to LabeledControl.

### DIFF
--- a/src/framework/labeledControl/LabeledControl.jsx
+++ b/src/framework/labeledControl/LabeledControl.jsx
@@ -21,12 +21,14 @@ const LabeledControl = props => {
 
   let label;
 
-  if (props.label) {
+  if (typeof props.label === 'string') {
     label = (
       <Label>
         {props.label}
       </Label>
     );
+  } else {
+    label = props.label;
   }
 
   return (
@@ -58,7 +60,7 @@ LabeledControl.propTypes = {
     PropTypes.array,
     PropTypes.element,
   ]),
-  label: PropTypes.string,
+  label: PropTypes.any,
   layout: PropTypes.string.isRequired,
   withLabeledField: PropTypes.bool,
 };

--- a/src/framework/labeledControl/LabeledControl.spec.jsx
+++ b/src/framework/labeledControl/LabeledControl.spec.jsx
@@ -18,7 +18,9 @@ describe('LabeledControl', () => {
     });
 
     describe('label', () => {
-      it('becomes the textContent of the label element', () => {
+      it(
+        'becomes the textContent of the label element when it\'s a string',
+      () => {
         const props = {
           label: 'Test',
         };
@@ -28,6 +30,20 @@ describe('LabeledControl', () => {
           props
         );
         expect(testCase.first('label').textContent).toBe(props.label);
+      });
+
+      it(
+        'is rendered when it isn\'t a string',
+      () => {
+        const props = {
+          label: <div id="test" />,
+        };
+
+        const testCase = TestCaseFactory.createFromFunction(
+          LabeledControl,
+          props
+        );
+        expect(testCase.first('#test')).toBeDefined();
       });
     });
 

--- a/src/guide/views/labeledControl/LabeledControlExample.jsx
+++ b/src/guide/views/labeledControl/LabeledControlExample.jsx
@@ -10,8 +10,10 @@ import Page, {
 
 import {
   Dropdown,
+  Label,
   LabeledControl,
   LabeledField,
+  SubLabel,
   TextArea,
   TextInput,
   VerticalLayout,
@@ -147,23 +149,33 @@ export default class LabelExample extends Component {
           </VerticalLayout>
         </Example>
 
+        <Example title="With Label and SubLabel">
+          <VerticalLayout>
+            <LabeledControl
+              label={[
+                <Label key={0}>Label</Label>,
+                <SubLabel key={1}>Sub-label</SubLabel>,
+              ]}
+              layout={LabeledControl.LAYOUT.ONE_SIXTH}
+            >
+              <TextInput isFullWidth />
+            </LabeledControl>
+          </VerticalLayout>
+        </Example>
+
         <Example title="With Dropdown">
           <VerticalLayout>
             <LabeledControl
               label="Type"
               layout={LabeledControl.LAYOUT.ONE_SIXTH}
             >
-              <LabeledField
-                label="Select your choice"
-              >
-                <Dropdown
-                  options={this.dropdownItems}
-                  selectedOption={this.state.selectedDropdownOption}
-                  onSelect={this.onSelectDropdownOption}
-                  labelProvider={this.dropdownLabelProvider}
-                  optionLabelProvider={this.dropdownOptionLabelProvider}
-                />
-              </LabeledField>
+              <Dropdown
+                options={this.dropdownItems}
+                selectedOption={this.state.selectedDropdownOption}
+                onSelect={this.onSelectDropdownOption}
+                labelProvider={this.dropdownLabelProvider}
+                optionLabelProvider={this.dropdownOptionLabelProvider}
+              />
             </LabeledControl>
           </VerticalLayout>
         </Example>


### PR DESCRIPTION
I figured we should play it safe and just support the provision of any kind of element as the `label` prop.
