### PR TITLE
[BT-480]: Add data-id to BaseDropdown, FieldMessage, Menu, PickedList, SummaryControl.

### DIFF
--- a/src/framework/baseDropdown/BaseDropdown.jsx
+++ b/src/framework/baseDropdown/BaseDropdown.jsx
@@ -198,7 +198,10 @@ export default class BaseDropdown extends Component {
     }
 
     return (
-      <div className={this.props.classes}>
+      <div
+        data-id={this.props.dataId}
+        className={this.props.classes}
+      >
         {/* Allow this component to be focusable by adding a hidden input. */}
         <input
           ref="input"
@@ -222,6 +225,7 @@ export default class BaseDropdown extends Component {
 }
 
 BaseDropdown.propTypes = {
+  dataId: PropTypes.string,
   classes: PropTypes.string.isRequired,
   inputClasses: PropTypes.string.isRequired,
   labelClasses: PropTypes.string.isRequired,

--- a/src/framework/baseDropdown/BaseDropdown.spec.jsx
+++ b/src/framework/baseDropdown/BaseDropdown.spec.jsx
@@ -1,5 +1,6 @@
 
 import { TestCaseFactory } from 'react-test-kit';
+import { CommonAssertions } from '../services';
 import BaseDropdown from './BaseDropdown.jsx';
 import BaseDropdownOption from './BaseDropdownOption.jsx';
 
@@ -45,6 +46,8 @@ describe('BaseDropdown', () => {
   });
 
   describe('Props', () => {
+    CommonAssertions.assertDataId(BaseDropdown, basicProps);
+
     describe('options', () => {
       it('populates the option list', () => {
         const options = [{

--- a/src/framework/fieldMessage/FieldMessage.jsx
+++ b/src/framework/fieldMessage/FieldMessage.jsx
@@ -4,12 +4,16 @@ import React, {
 } from 'react';
 
 const FieldMessage = props => (
-  <div className="fieldMessage">
+  <div
+    data-id={props.dataId}
+    className="fieldMessage"
+  >
     {props.message}
   </div>
 );
 
 FieldMessage.propTypes = {
+  dataId: PropTypes.string,
   message: PropTypes.string.isRequired,
 };
 

--- a/src/framework/fieldMessage/FieldMessage.spec.jsx
+++ b/src/framework/fieldMessage/FieldMessage.spec.jsx
@@ -1,9 +1,12 @@
 
 import { TestCaseFactory } from 'react-test-kit';
+import { CommonAssertions } from '../services';
 import FieldMessage from './FieldMessage.jsx';
 
 describe('FieldMessage', () => {
   describe('Props', () => {
+    CommonAssertions.assertDataId(FieldMessage);
+
     describe('message', () => {
       it('is rendered as text', () => {
         const props = {

--- a/src/framework/menu/Menu.jsx
+++ b/src/framework/menu/Menu.jsx
@@ -8,12 +8,13 @@ export {
 } from './MenuItem.jsx';
 
 const Menu = props => (
-  <div>
+  <div data-id={props.dataId}>
     {props.children}
   </div>
 );
 
 Menu.propTypes = {
+  dataId: PropTypes.string,
   children: PropTypes.any,
 };
 

--- a/src/framework/menu/Menu.spec.jsx
+++ b/src/framework/menu/Menu.spec.jsx
@@ -1,9 +1,12 @@
 
 import { TestCaseFactory } from 'react-test-kit';
+import { CommonAssertions } from '../services';
 import Menu from './Menu.jsx';
 
 describe('Menu', () => {
   describe('Props', () => {
+    CommonAssertions.assertDataId(Menu);
+
     describe('children', () => {
       it('is rendered', () => {
         const props = {

--- a/src/framework/pickedList/PickedList.jsx
+++ b/src/framework/pickedList/PickedList.jsx
@@ -12,13 +12,17 @@ const PickedList = props => (
     <div className="pickedListTitle">
       {props.title}
     </div>
-    <div className="pickedList">
+    <div
+      data-id={props.dataId}
+      className="pickedList"
+    >
       {props.children}
     </div>
   </div>
 );
 
 PickedList.propTypes = {
+  dataId: PropTypes.string,
   children: PropTypes.any,
   title: PropTypes.string.isRequired,
 };

--- a/src/framework/pickedList/PickedList.spec.jsx
+++ b/src/framework/pickedList/PickedList.spec.jsx
@@ -1,9 +1,12 @@
 
 import { TestCaseFactory } from 'react-test-kit';
+import { CommonAssertions } from '../services';
 import PickedList from './PickedList.jsx';
 
 describe('PickedList', () => {
   describe('Props', () => {
+    CommonAssertions.assertDataId(PickedList, undefined, '.pickedList');
+
     describe('children', () => {
       it('is rendered', () => {
         const props = {

--- a/src/framework/summaryControl/SummaryControl.jsx
+++ b/src/framework/summaryControl/SummaryControl.jsx
@@ -7,6 +7,7 @@ import IconCog from '../icon/IconCog.jsx';
 
 const SummaryControl = props => (
   <div
+    data-id={props.dataId}
     className="summaryControl"
     onClick={props.onClick}
   >
@@ -19,6 +20,7 @@ const SummaryControl = props => (
 );
 
 SummaryControl.propTypes = {
+  dataId: PropTypes.string,
   children: PropTypes.string,
   icon: PropTypes.any,
   onClick: PropTypes.func,

--- a/src/framework/summaryControl/SummaryControl.spec.jsx
+++ b/src/framework/summaryControl/SummaryControl.spec.jsx
@@ -1,10 +1,13 @@
 
 import React from 'react';
 import { TestCaseFactory } from 'react-test-kit';
+import { CommonAssertions } from '../services';
 import SummaryControl from './SummaryControl.jsx';
 
 describe('SummaryControl', () => {
   describe('Props', () => {
+    CommonAssertions.assertDataId(SummaryControl);
+
     describe('children', () => {
       it('is rendered', () => {
         const props = {


### PR DESCRIPTION
It seems like we will be able to use the data-id prop on these components in our E2E tests in the near future.
