### PR TITLE
[BT-657]: Truncate text when Dropdown is narrower than its label.

### DIFF
--- a/src/framework/columnLayout/ColumnLayout.jsx
+++ b/src/framework/columnLayout/ColumnLayout.jsx
@@ -8,9 +8,7 @@ export {
 } from './Column.jsx';
 
 const ColumnLayout = props => (
-  <div
-    className="columnLayout"
-  >
+  <div>
     {props.children}
   </div>
 );

--- a/src/framework/columnLayout/_columnLayout.scss
+++ b/src/framework/columnLayout/_columnLayout.scss
@@ -1,15 +1,17 @@
 
-.columnLayout {
-  display: flex;
-}
-
 .column + .column {
   padding-left: 10px;
 }
 
+/**
+ * 1. Use inline-block instead of flexbox so that content doesn't overflow.
+ * 2. Content can be aligned by offsetting from the top.
+ */
 $numColumns: 12;
 @for $i from 1 through $numColumns {
   .column--#{$i} {
-    flex: 0 0 $i / $numColumns * 100%;
+    display: inline-block; /* 1 */
+    vertical-align: top; /* 2 */
+    width: $i / $numColumns * 100%;
   }
 }

--- a/src/framework/dropdown/_dropdown.scss
+++ b/src/framework/dropdown/_dropdown.scss
@@ -1,15 +1,24 @@
 
+/**
+ * 1. Make sure dropdown doesn't exceed the width of its container, e.g. modal.
+ */
 .dropdown {
   @include baseDropdown;
   display: inline-block;
+  max-width: 100%; /* 1 */
 }
 
   .dropdown__input {
     @include baseDropdownInput;
   }
 
+/**
+ * 1. If the dropdown is narrower than its label, truncate the text.
+ */
 .dropdownLabel {
   @include baseDropdownLabel;
+  text-overflow: ellipsis; /* 1 */
+  overflow: hidden; /* 1 */
   font-size: 12px;
   line-height: $lineHeight;
   font-weight: 400;

--- a/src/guide/index.scss
+++ b/src/guide/index.scss
@@ -9,7 +9,7 @@ $sourceCodeViewerWidth: 600px;
   color: #626262;
   cursor: pointer;
   user-select: none;
-  opacity: 0.3;
+  opacity: 0.75;
   background: #e7e7ed;
   border: 1px solid transparent;
   transition: color 0.2s,

--- a/src/guide/views/modal/ModalExample.jsx
+++ b/src/guide/views/modal/ModalExample.jsx
@@ -26,6 +26,7 @@ import {
   ModalOverlay,
   ModalStack,
   PrimaryButton,
+  Text,
   TextInput,
   VerticalLayout,
 } from '../../../framework/framework';
@@ -40,7 +41,7 @@ export default class ModalExample extends Component {
       stackedModalCount: 0,
     };
 
-    this.STACKED_MODAL_WIDTH = 750;
+    this.STACKED_MODAL_WIDTH = 400;
 
     this.addModalToStack = this.addModalToStack.bind(this);
     this.removeModalFromStack = this.removeModalFromStack.bind(this);
@@ -93,25 +94,40 @@ export default class ModalExample extends Component {
         </ModalHeader>
         <ModalBody>
           <div>
-            Modal content. This dropdown demonstrates that it isn't cropped when
-            it's opened.
+            <Text rhythm={Text.RHYTHM.SMALL}>
+              This dropdown demonstrates two things: 1) it isn't
+              cropped when it's open, 2) it isn't cropped when it's wider than
+              the modal.
+            </Text>
           </div>
-          <Dropdown
-            options={[{
-              name: 'Apple',
-            }, {
-              name: 'Berry',
-            }, {
-              name: 'Corn',
-            }, {
-              name: 'Daffodil',
-            }, {
-              name: 'Eggplant',
-            }]}
-            onSelect={() => undefined} // eslint-disable-line react/jsx-no-bind
-            labelProvider={() => 'Click me'} // eslint-disable-line react/jsx-no-bind
-            optionLabelProvider={option => option.name} // eslint-disable-line react/jsx-no-bind
-          />
+          <ColumnLayout>
+            <Column width={4}>
+              <Label isAlignedWithField>
+                Dropdown
+              </Label>
+            </Column>
+            <Column width={8}>
+              <Dropdown
+                options={[{
+                  name: 'Apple',
+                }, {
+                  name: 'Berry',
+                }, {
+                  name: 'Corn',
+                }, {
+                  name: 'Daffodil',
+                }, {
+                  name: 'Eggplant',
+                }]}
+                onSelect={() => undefined} // eslint-disable-line react/jsx-no-bind
+                labelProvider={() => // eslint-disable-line react/jsx-no-bind
+                  `This dropdown should be wider than this modal, but it should
+                  not be cropped.`
+                }
+                optionLabelProvider={option => option.name} // eslint-disable-line react/jsx-no-bind
+              />
+            </Column>
+          </ColumnLayout>
         </ModalBody>
         <ModalFooter
           right={


### PR DESCRIPTION
- Refactor ColumnLayout to use inline-block instead of flexbox.

![image](https://cloud.githubusercontent.com/assets/1238659/15025856/34f63f6a-11f0-11e6-97e8-e9d0a66c6805.png)

![image](https://cloud.githubusercontent.com/assets/1238659/15026036/1ab1c312-11f1-11e6-82ff-bf3ddadf31d5.png)
