### PR TITLE
[BT-686]: Add CSS dependency upon published icon-library CSS.

### DIFF
--- a/src/guide/index.jade
+++ b/src/guide/index.jade
@@ -21,6 +21,13 @@ html(lang='en')
       type = "text/css"
     )
 
+    //- Icons
+    link(
+      href = "//smaatoui.github.io/icon-library/css/icons.css"
+      rel = "stylesheet"
+      type = "text/css"
+    )
+
   body
     #app
     script(


### PR DESCRIPTION
This will allow us to develop the UI Framework (and will let others view it) with icons from the icon-library, without violating the prohibition against distribution. My reasoning is that since we can share the icons to our BT users via a CSS file, we can share the icons elsewhere via a CSS file too.