### PR TITLE
[BT-685]: Rename Sorter.simpleSort to sortBy.

### DIFF
--- a/src/framework/services/sort/Sorter.js
+++ b/src/framework/services/sort/Sorter.js
@@ -10,37 +10,50 @@ function normalizeValue(value) {
 
 function sort(
   originalItems,
-  valueProviderOrProviders,
+  propertyNameOrValueProviderOrProviders,
   providerPropertyOrIndex,
   isDescending = false
 ) {
-  const isSingleValueProvider = typeof valueProviderOrProviders === 'function';
+  const isPropertyName =
+    typeof propertyNameOrValueProviderOrProviders === 'string';
 
-  // If we've received an array of value providers, then we need to make sure
-  // an acceptable providerPropertyOrIndex has been provided.
-  if (!isSingleValueProvider) {
-    const typeOfProviderPropertyOrIndex = typeof providerPropertyOrIndex;
-    if (typeOfProviderPropertyOrIndex !== 'string' &&
-      typeOfProviderPropertyOrIndex !== 'number') {
-      throw new Error(
-        `providerPropertyOrIndex must be a string or number.
-        Got ${providerPropertyOrIndex}.`
-      );
+  const isSingleValueProvider =
+    typeof propertyNameOrValueProviderOrProviders === 'function';
+
+  if (!isPropertyName) {
+    // If we've received an array of value providers, then we need to make sure
+    // an acceptable providerPropertyOrIndex has been provided.
+    if (!isSingleValueProvider) {
+      const typeOfProviderPropertyOrIndex = typeof providerPropertyOrIndex;
+      if (typeOfProviderPropertyOrIndex !== 'string' &&
+        typeOfProviderPropertyOrIndex !== 'number') {
+        throw new Error(
+          `providerPropertyOrIndex must be a string or number.
+          Got ${providerPropertyOrIndex}.`
+        );
+      }
     }
   }
 
   const items = originalItems.slice();
 
   return items.sort((a, b) => {
-    const providedValueA =
-      isSingleValueProvider
-      ? valueProviderOrProviders(a)
-      : valueProviderOrProviders[providerPropertyOrIndex](a);
+    let providedValueA;
+    let providedValueB;
 
-    const providedValueB =
-      isSingleValueProvider
-      ? valueProviderOrProviders(b)
-      : valueProviderOrProviders[providerPropertyOrIndex](b);
+    if (isPropertyName) {
+      providedValueA = a[propertyNameOrValueProviderOrProviders];
+      providedValueB = b[propertyNameOrValueProviderOrProviders];
+    } else if (isSingleValueProvider) {
+      providedValueA = propertyNameOrValueProviderOrProviders(a);
+      providedValueB = propertyNameOrValueProviderOrProviders(b);
+    } else {
+      // Default to assuming there are multiple value providers.
+      providedValueA =
+        propertyNameOrValueProviderOrProviders[providerPropertyOrIndex](a);
+      providedValueB =
+        propertyNameOrValueProviderOrProviders[providerPropertyOrIndex](b);
+    }
 
     let valueA;
     let valueB;
@@ -88,18 +101,23 @@ function sort(
   });
 }
 
-function simpleSort(
+function sortBy(
   originalItems,
-  valueProvider,
+  propertyNameOrValueProvider,
   isDescending
 ) {
-  return Sorter.sort(originalItems, valueProvider, undefined, isDescending);
+  return Sorter.sort(
+    originalItems,
+    propertyNameOrValueProvider,
+    undefined,
+    isDescending
+  );
 }
 
 Sorter = {
   normalizeValue,
-  simpleSort,
   sort,
+  sortBy,
 };
 
 export default Sorter;

--- a/src/framework/services/sort/Sorter.spec.js
+++ b/src/framework/services/sort/Sorter.spec.js
@@ -63,10 +63,10 @@ describe('Sorter', () => {
       });
     });
 
-    describe('simpleSort method', () => {
+    describe('sortBy method', () => {
       it('delegates to the sort method', () => {
         spyOn(Sorter, 'sort');
-        Sorter.simpleSort(items, valueProvider);
+        Sorter.sortBy(items, valueProvider);
         expect(Sorter.sort)
           .toHaveBeenCalledWith(items, valueProvider, undefined, undefined);
       });
@@ -118,15 +118,38 @@ describe('Sorter', () => {
         });
       });
 
-      describe('valueProviderOrProviders parameter', () => {
-        it('provides a single function that provides sort values', () => {
+      describe('propertyNameOrValueProviderOrProviders parameter', () => {
+        it('can be a property name that provides sort values', () => {
+          const sortedItems = Sorter.sort(items, 'b');
+          expect(sortedItems).toEqual([{
+            a: 2,
+            b: 1,
+          }, {
+            a: 1,
+            b: 2,
+          }, {
+            a: 'TestB1',
+            b: 'TestA2',
+          }, {
+            a: 'TestA1',
+            b: 'TestB2',
+          }, {
+            a: null,
+            b: null,
+          }, {
+            a: undefined,
+            b: undefined,
+          }]);
+        });
+
+        it('can be a single function that provides sort values', () => {
           const fakeItems = ['item1', 'item2'];
           const provider = jasmine.createSpy('provider');
           Sorter.sort(fakeItems, provider);
           expect(provider).toHaveBeenCalledWith(fakeItems[0]);
         });
 
-        it('provides functions that provide sort values', () => {
+        it('can be an array of functions that provide sort values', () => {
           const fakeItems = ['item1', 'item2'];
           const providers = [jasmine.createSpy('provider')];
           Sorter.sort(fakeItems, providers, 0);

--- a/src/framework/services/sort/Sorter.spec.js
+++ b/src/framework/services/sort/Sorter.spec.js
@@ -73,29 +73,29 @@ describe('Sorter', () => {
     });
 
     describe('sort method', () => {
-      const valueProvidersByIndex = [
+      const valueProvidersArray = [
         item => item.a,
         item => item.b,
       ];
 
       it('returns a new array', () => {
-        const test = items === Sorter.sort(items, valueProvidersByIndex, 0);
+        const test = items === Sorter.sort(items, valueProvidersArray, 0);
         expect(test).toBe(false);
       });
 
       describe('originalItems parameter', () => {
         it('isn\'t sorted if it has 0 items', () => {
-          const sortedItems = Sorter.sort([], valueProvidersByIndex, 0);
+          const sortedItems = Sorter.sort([], valueProvidersArray, 0);
           expect(sortedItems).toEqual([]);
         });
 
         it('isn\'t sorted if it has 1 item', () => {
-          const sortedItems = Sorter.sort(['item'], valueProvidersByIndex, 0);
+          const sortedItems = Sorter.sort(['item'], valueProvidersArray, 0);
           expect(sortedItems).toEqual(['item']);
         });
 
         it('is sorted in order of numbers. strings, null, undefined', () => {
-          const sortedItems = Sorter.sort(items, valueProvidersByIndex, 0);
+          const sortedItems = Sorter.sort(items, valueProvidersArray, 0);
           expect(sortedItems).toEqual([{
             a: 1,
             b: 2,
@@ -118,7 +118,7 @@ describe('Sorter', () => {
         });
       });
 
-      describe('propertyNameOrValueProviderOrProviders parameter', () => {
+      describe('keyOrValueProviderOrProviders parameter', () => {
         it('can be a property name that provides sort values', () => {
           const sortedItems = Sorter.sort(items, 'b');
           expect(sortedItems).toEqual([{
@@ -160,7 +160,7 @@ describe('Sorter', () => {
       describe('isDescending parameter', () => {
         describe('when false (default)', () => {
           it('sorts items ascending', () => {
-            const sortedItems = Sorter.sort(items, valueProvidersByIndex, 0);
+            const sortedItems = Sorter.sort(items, valueProvidersArray, 0);
             expect(sortedItems).toEqual([{
               a: 1,
               b: 2,
@@ -189,7 +189,7 @@ describe('Sorter', () => {
             strings, numbers when true`
           ), () => {
             const sortedItems =
-              Sorter.sort(items, valueProvidersByIndex, 0, true);
+              Sorter.sort(items, valueProvidersArray, 0, true);
 
             expect(sortedItems).toEqual([{
               a: undefined,
@@ -214,7 +214,7 @@ describe('Sorter', () => {
         });
       });
 
-      describe('providerPropertyOrIndex parameter', () => {
+      describe('providerKeyOrIndex parameter', () => {
         describe('when there is a single value provider', () => {
           it('doesn\'t throw an error if undefined', () => {
             expect(
@@ -232,19 +232,19 @@ describe('Sorter', () => {
         describe('when there are multiple value providers', () => {
           it('throws an error if undefined', () => {
             expect(
-              () => Sorter.sort(items, valueProvidersByIndex, undefined)
+              () => Sorter.sort(items, valueProvidersArray, undefined)
             ).toThrowError();
           });
 
           it('throws an error if null', () => {
             expect(
-              () => Sorter.sort(items, valueProvidersByIndex, null)
+              () => Sorter.sort(items, valueProvidersArray, null)
             ).toThrowError();
           });
 
-          it('defines a provider via an element index', () => {
+          it('defines a provider via an index', () => {
             const sortedItems =
-              Sorter.sort(items, valueProvidersByIndex, 1);
+              Sorter.sort(items, valueProvidersArray, 1);
 
             expect(sortedItems).toEqual([{
               a: 2,
@@ -267,13 +267,13 @@ describe('Sorter', () => {
             }]);
           });
 
-          it('defines a provider via a property name', () => {
-            const valueProvidersByProperty = {
-              a: item => item.a,
-              b: item => item.b,
+          it('defines a provider via a key', () => {
+            const valueProvidersObject = {
+              provider1: item => item.a,
+              provider2: item => item.b,
             };
             const sortedItems =
-              Sorter.sort(items, valueProvidersByProperty, 'b');
+              Sorter.sort(items, valueProvidersObject, 'provider2');
 
             expect(sortedItems).toEqual([{
               a: 2,


### PR DESCRIPTION
- Improve sort method to accept a property name as a value provider.