### PR TITLE
SDX-1159 Disable shorthand rule

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -153,7 +153,7 @@ linters:
     convention: strict_BEM # or 'hyphenated_BEM', or 'hyphenated_lowercase', or 'snake_case', or 'camel_case', or a regex pattern
 
   Shorthand:
-    enabled: true
+    enabled: false
     allowed_shorthands: [1, 2, 3]
 
   SingleLinePerProperty:


### PR DESCRIPTION
_Copied from the ticket comment_

The behavior of `allowed_shorthands` was changed in SCSS-Lint 0.49.0. Now it first checks the number of values and, if it is not in `allowed_shorthands`, raises a warning (see https://github.com/brigade/scss-lint/commit/e283d1689699f581561fea344df3168128c46d7b#diff-dd4f5c93fac40b72bbc817e731e18859).

I propose to simply remove the shorthand rule. I checked that after removal the warnings will still be raised in case a shorter form is possible.
