### PR TITLE
TF-392: Fix circular dependencies in Button and Kpi components

### DIFF
--- a/src/framework/button/Button.jsx
+++ b/src/framework/button/Button.jsx
@@ -97,29 +97,3 @@ Button.propTypes = {
 };
 
 export default Button;
-
-// We need to export these components after the default export because they
-// depend on it.
-export {
-  default as AlertButton,
-} from './AlertButton.jsx';
-
-export {
-  default as BasicButton,
-} from './BasicButton.jsx';
-
-export {
-  default as CallOutButton,
-} from './CallOutButton.jsx';
-
-export {
-  default as GroupedButton,
-} from './GroupedButton.jsx';
-
-export {
-  default as HollowButton,
-} from './HollowButton.jsx';
-
-export {
-  default as PrimaryButton,
-} from './PrimaryButton.jsx';

--- a/src/framework/button/index.jsx
+++ b/src/framework/button/index.jsx
@@ -1,0 +1,27 @@
+export {
+    default as Button,
+} from './Button.jsx';
+
+export {
+  default as AlertButton,
+} from './AlertButton.jsx';
+
+export {
+  default as BasicButton,
+} from './BasicButton.jsx';
+
+export {
+  default as CallOutButton,
+} from './CallOutButton.jsx';
+
+export {
+  default as GroupedButton,
+} from './GroupedButton.jsx';
+
+export {
+  default as HollowButton,
+} from './HollowButton.jsx';
+
+export {
+  default as PrimaryButton,
+} from './PrimaryButton.jsx';

--- a/src/framework/framework.js
+++ b/src/framework/framework.js
@@ -15,8 +15,7 @@ export { default as Body } from './body/Body.jsx';
 
 export { default as Box } from './box/Box.jsx';
 
-export * from './button/Button.jsx';
-export { default as Button } from './button/Button.jsx';
+export * from './button/index.jsx';
 
 export { default as ButtonGroup } from './buttonGroup/ButtonGroup.jsx';
 
@@ -49,8 +48,7 @@ export { default as Grid } from './grid/Grid.jsx';
 
 export { default as HorizontalLine } from './horizontalLine/HorizontalLine.jsx';
 
-export * from './kpi/Kpi.jsx';
-export { default as Kpi } from './kpi/Kpi.jsx';
+export * from './kpi/index.jsx';
 
 export * from './label/Label.jsx';
 export { default as Label } from './label/Label.jsx';

--- a/src/framework/kpi/Kpi.jsx
+++ b/src/framework/kpi/Kpi.jsx
@@ -24,11 +24,3 @@ Kpi.propTypes = {
 };
 
 export default Kpi;
-
-export {
-  default as KpiPositive,
-} from './KpiPositive.jsx';
-
-export {
-  default as KpiNegative,
-} from './KpiNegative.jsx';

--- a/src/framework/kpi/index.jsx
+++ b/src/framework/kpi/index.jsx
@@ -1,0 +1,11 @@
+export {
+    default as Kpi,
+} from './Kpi.jsx';
+
+export {
+  default as KpiPositive,
+} from './KpiPositive.jsx';
+
+export {
+  default as KpiNegative,
+} from './KpiNegative.jsx';


### PR DESCRIPTION
As `webpack` can't handle circular dependencies (see https://github.com/webpack/webpack/issues/1788) UI-Framework can't be imported to projects compiled with `webpack`/`babel`. 

This PR removes circular imports from two files: `Button.jsx` and `Kpi.jsx` and replaces them with separate export files (`index.jsx`) for all related components. This way child components (like `HollowButton`) can rely on parents code (e.g. `Button.TYPE`) as they are imported from `index.jsx` not `Button.jsx` file.

As far as I know all exports behave exactly the same way as previously, so this shouldn't introduce any regression. Also, all units test pass locally. Unfortunately as an external developer I can't test this with other apps using the framework, so before merging **please** test this thoroughly. 

Any questions please let me know!